### PR TITLE
Update e2e test data bucket address

### DIFF
--- a/e2e.py
+++ b/e2e.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         file_path.unlink()
 
     # Download file from gsutil
-    os.system("gsutil -m cp -r gs://blocks-e2e-testing/e2e_kmeans_clustering/* %s" % INPUT_DIR)
+    os.system("gsutil -m cp -r gs://floss-blocks-e2e-testing/e2e_kmeans_clustering/* %s" % INPUT_DIR)
 
     RUN_CMD = """docker run -v %s:/tmp \
                  -e 'UP42_TASK_PARAMETERS={"n_clusters":8}' \


### PR DESCRIPTION
Uses an open GCS bucket to fetch e2e test data from.