### PR TITLE
Add image size limit

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">87%</text>
-        <text x="80" y="14">87%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
+        <text x="80" y="14">89%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="#97CA00" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
-        <text x="80" y="14">89%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
+        <text x="80" y="14">91%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#fe7d37" d="M63 0h36v20H63z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">49%</text>
-        <text x="80" y="14">49%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">67%</text>
+        <text x="80" y="14">67%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#dfb317" d="M63 0h36v20H63z"/>
+        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">67%</text>
-        <text x="80" y="14">67%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">87%</text>
+        <text x="80" y="14">87%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">52%</text>
-        <text x="80" y="14">52%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">49%</text>
+        <text x="80" y="14">49%</text>
     </g>
 </svg>

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,3 +1,3 @@
 {
-"publicVersion": "2.0.3"
+"publicVersion": "2.0.4"
 }

--- a/pylintrc
+++ b/pylintrc
@@ -8,8 +8,13 @@ disable=
     too-few-public-methods,
     missing-final-newline,
     too-many-boolean-expressions,
+    unsubscriptable-object,
+    no-member,
+    fixme,
     bad-continuation,
-    fixme
+    duplicate-code,
+    logging-fstring-interpolation,
+    logging-format-interpolation
 
 [FORMAT]
 max-line-length=120
@@ -24,3 +29,7 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|logger|api|_api)$
 [DESIGN]
 max-args=6
 ignored-argument-names=_.*|self
+
+[SIMILARITIES]
+# Minimum lines number of a similarity.
+min-similarity-lines=7

--- a/src/kmeans_clustering.py
+++ b/src/kmeans_clustering.py
@@ -28,9 +28,7 @@ def raise_if_too_large(input_ds: rio.DatasetReader, max_size_bytes: int = 214748
     else:
         multiplier = 2
 
-    expected_size = (
-        input_ds.shape[0] * input_ds.shape[1] * input_ds.shape[2] * multiplier
-    )
+    expected_size = input_ds.shape[0] * input_ds.shape[1] * input_ds.count * multiplier
 
     if expected_size > max_size_bytes:
         raise UP42Error(

--- a/src/kmeans_clustering.py
+++ b/src/kmeans_clustering.py
@@ -139,13 +139,13 @@ class KMeansClustering(ProcessingBlock):
 
             out_feature = feature.copy()
             out_feature["properties"]["up42.data_path"] = path_to_output_img
-            results.append(out_feature)
 
             try:
                 self.run_kmeans_clustering(
                     "/tmp/input/" + path_to_input_img,
                     "/tmp/output/" + path_to_output_img,
                 )
+                results.append(out_feature)
             except UP42Error as e:
                 logger.warning(e)
                 logger.warning(

--- a/src/kmeans_clustering.py
+++ b/src/kmeans_clustering.py
@@ -16,8 +16,9 @@ from blockutils.exceptions import UP42Error, SupportedErrors
 logger = get_logger(__name__)
 
 
-def raise_if_too_large(input_ds: rio.DatasetReader, max_size_bytes: int = 21474825484):
-    # xlarge image has 20GB RAM
+def raise_if_too_large(input_ds: rio.DatasetReader, max_size_bytes: int = 2415919104):
+    # xlarge image has 20GB
+    # Using 18 GB as max in memory for safety as default - 2415919104 bytes
 
     if input_ds.meta["dtype"] == "uint8":
         multiplier = 1.4

--- a/src/kmeans_clustering.py
+++ b/src/kmeans_clustering.py
@@ -17,8 +17,24 @@ logger = get_logger(__name__)
 
 
 def raise_if_too_large(input_ds: rio.DatasetReader, max_size_bytes: int = 31621877760):
-    # xlarge image has 31621877760 bytes memory
-    #
+    """Raises UP42Error if input dataset allocation in memory expected_size
+    max_size_bytes.
+
+    Xlarge machine has 31621877760 bytes memory
+
+    Parameters
+    ----------
+    input_ds : rio.DatasetReader
+        A raster dataset.
+    max_size_bytes : int
+        Maximum allowed size of dataset in bytes (usually memory in machine)
+
+    Raises
+    -------
+    UP42Error
+        When estimated input dataset allocation in memory exceedes max_size_bytes
+
+    """
 
     if input_ds.meta["dtype"] == "uint8":
         multiplier = 8
@@ -34,6 +50,7 @@ def raise_if_too_large(input_ds: rio.DatasetReader, max_size_bytes: int = 316218
         input_ds.shape[0] * input_ds.shape[1] * input_ds.count * multiplier
     ) / 8
     # KMeansClustering algorithm uses at least x4 size of image in bytes in memory
+    # Add x4 buffer for safety
     expected_size *= 4 * 4
     logger.info(f"expected_size is {expected_size}")
 

--- a/src/kmeans_clustering.py
+++ b/src/kmeans_clustering.py
@@ -35,10 +35,10 @@ def raise_if_too_large(input_ds: rio.DatasetReader, max_size_bytes: int = 316218
     ) / 8
     # KMeansClustering algorithm uses at least x4 size of image in bytes in memory
     expected_size *= 4 * 4
-    logger.info("expected_size is %d" % expected_size)
+    logger.info(f"expected_size is {expected_size}")
 
     if expected_size > max_size_bytes:
-        logger.info("expected_size is more than %d" % max_size_bytes)
+        logger.info(f"expected_size is more than {max_size_bytes}")
         raise UP42Error(
             SupportedErrors.WRONG_INPUT_ERROR,
             "Dataset is too large! Please select a smaller AOI.",

--- a/tests/context.py
+++ b/tests/context.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # pylint: disable=unused-import
-from src.kmeans_clustering import KMeansClustering
+from src.kmeans_clustering import KMeansClustering, raise_if_too_large
 
 # Path hacks to make the code available for testing
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_kmeans_clustering.py
+++ b/tests/test_kmeans_clustering.py
@@ -1,9 +1,12 @@
+import unittest.mock as mock
+
 import numpy as np
 import pytest
 
 from blockutils.common import ensure_data_directories_exist
+from blockutils.exceptions import UP42Error
 
-from context import KMeansClustering
+from context import KMeansClustering, raise_if_too_large
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -27,3 +30,26 @@ def test_kmeans_clustering():
     assert len(np.unique(clusters_ar)) == 3
     assert np.min(clusters_ar) == 0
     assert np.max(clusters_ar) == 2
+
+
+def test_raise_if_too_large():
+    with mock.patch("rasterio.DatasetReader") as src:
+        instance = src.return_value
+        instance.meta["dtype"] = "uint8"
+        instance.shape = (10, 10, 4)
+        raise_if_too_large(instance)
+
+        with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
+            instance.meta["dtype"] = "float"
+            instance.shape = (500000, 500000, 4)
+            raise_if_too_large(instance)
+
+        with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
+            instance.meta["dtype"] = "uint8"
+            instance.shape = (500000, 500000, 4)
+            raise_if_too_large(instance)
+
+        with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
+            instance.meta["dtype"] = "uint16"
+            instance.shape = (500000, 500000, 4)
+            raise_if_too_large(instance)

--- a/tests/test_kmeans_clustering.py
+++ b/tests/test_kmeans_clustering.py
@@ -53,3 +53,8 @@ def test_raise_if_too_large():
             instance.meta["dtype"] = "uint16"
             instance.shape = (500000, 500000, 4)
             raise_if_too_large(instance)
+
+        with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
+            instance.meta["dtype"] = "uint8"
+            instance.shape = (10, 10, 4)
+            raise_if_too_large(instance, 1)

--- a/tests/test_kmeans_clustering.py
+++ b/tests/test_kmeans_clustering.py
@@ -69,25 +69,30 @@ def test_raise_if_too_large():
     with mock.patch("rasterio.DatasetReader") as src:
         instance = src.return_value
         instance.meta["dtype"] = "uint8"
-        instance.shape = (10, 10, 4)
+        instance.count = 4
+        instance.shape = (10, 10)
         raise_if_too_large(instance)
 
         with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
             instance.meta["dtype"] = "float"
-            instance.shape = (500000, 500000, 4)
+            instance.count = 4
+            instance.shape = (500000, 500000)
             raise_if_too_large(instance)
 
         with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
             instance.meta["dtype"] = "uint8"
-            instance.shape = (500000, 500000, 4)
+            instance.count = 4
+            instance.shape = (500000, 500000)
             raise_if_too_large(instance)
 
         with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
             instance.meta["dtype"] = "uint16"
-            instance.shape = (500000, 500000, 4)
+            instance.count = 4
+            instance.shape = (500000, 500000)
             raise_if_too_large(instance)
 
         with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
             instance.meta["dtype"] = "uint8"
-            instance.shape = (10, 10, 4)
+            instance.count = 4
+            instance.shape = (10, 10)
             raise_if_too_large(instance, 1)

--- a/tests/test_kmeans_clustering.py
+++ b/tests/test_kmeans_clustering.py
@@ -64,6 +64,9 @@ def test_process():
         output_fc = lcc.process(input_fc)
         assert output_fc.features
 
+        with pytest.raises(UP42Error, match=r".*[NO_INPUT_ERROR].*"):
+            lcc.process(FeatureCollection([]))
+
 
 def test_raise_if_too_large():
     with mock.patch("rasterio.DatasetReader") as src:

--- a/tests/test_kmeans_clustering.py
+++ b/tests/test_kmeans_clustering.py
@@ -77,25 +77,31 @@ def test_raise_if_too_large():
         raise_if_too_large(instance)
 
         with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
-            instance.meta["dtype"] = "float"
+            instance.meta = {"dtype": "float32"}
             instance.count = 4
             instance.shape = (500000, 500000)
             raise_if_too_large(instance)
 
         with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
-            instance.meta["dtype"] = "uint8"
+            instance.meta = {"dtype": "uint8"}
             instance.count = 4
             instance.shape = (500000, 500000)
             raise_if_too_large(instance)
 
         with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
-            instance.meta["dtype"] = "uint16"
+            instance.meta = {"dtype": "uint16"}
             instance.count = 4
             instance.shape = (500000, 500000)
             raise_if_too_large(instance)
 
         with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
-            instance.meta["dtype"] = "uint8"
+            instance.meta = {"dtype": "uint8"}
             instance.count = 4
             instance.shape = (10, 10)
             raise_if_too_large(instance, 1)
+
+        with pytest.raises(UP42Error, match=r".*[WRONG_INPUT_ERROR].*"):
+            instance.meta = {"dtype": "float32"}
+            instance.count = 1
+            instance.shape = (28873, 22291)
+            raise_if_too_large(instance)


### PR DESCRIPTION
Avoids memory error when very large images are trying to be processed.

Current implementation assumes a limit of about 1,2GB in a single image. If there are several images to be processed, the results will only be the images that are under the size limitation, and a warning is given in the logs for this.

- [x] Bump version
- [x] Update documentation - PR https://github.com/up42/docs/pull/196
- [x] Add raise if limit function and tests
- [x] Adds test for process method