### PR TITLE
Respect nodata up4851

### DIFF
--- a/UP42Manifest.json
+++ b/UP42Manifest.json
@@ -27,12 +27,6 @@
       "required": false,
       "description": "Minimum number of pixels in each patch for the classification",
       "default": 64
-    },
-    "propagate_nodata": {
-      "type":  "boolean",
-      "required": false,
-      "description": "Nodata pixels in input pixels are also set to nodata in output",
-      "default": false
     }
   },
   "machine": {

--- a/UP42Manifest.json
+++ b/UP42Manifest.json
@@ -27,6 +27,12 @@
       "required": false,
       "description": "Minimum number of pixels in each patch for the classification",
       "default": 64
+    },
+    "propagate_nodata": {
+      "type":  "boolean",
+      "required": false,
+      "description": "Nodata pixels in input pixels are also set to nodata in output",
+      "default": false
     }
   },
   "machine": {

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
-        <text x="80" y="14">91%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">90%</text>
+        <text x="80" y="14">90%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#97CA00" d="M63 0h36v20H63z"/>
+        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">90%</text>
-        <text x="80" y="14">90%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
+        <text x="80" y="14">89%</text>
     </g>
 </svg>

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,3 +1,3 @@
 {
-"publicVersion": "2.0.4"
+"publicVersion": "2.1.0"
 }

--- a/src/kmeans_clustering.py
+++ b/src/kmeans_clustering.py
@@ -70,7 +70,11 @@ class KMeansClustering(ProcessingBlock):
     """
 
     def __init__(
-        self, n_clusters: int = 6, n_iterations: int = 10, n_sieve_pixels: int = 64
+        self,
+        n_clusters: int = 6,
+        n_iterations: int = 10,
+        n_sieve_pixels: int = 64,
+        propagate_nodata: bool = False,
     ):
         """
         It is possible to set all parameters for testing etc, but in a standard scenario
@@ -84,6 +88,7 @@ class KMeansClustering(ProcessingBlock):
         self.n_clusters = n_clusters
         self.n_iterations = n_iterations
         self.n_sieve_pixels = n_sieve_pixels
+        self.propagate_nodata = propagate_nodata
 
     def run_kmeans(self, img_ar: np.ndarray) -> np.ndarray:
         """
@@ -115,7 +120,9 @@ class KMeansClustering(ProcessingBlock):
 
         return cluster_indices
 
-    def run_kmeans_clustering(self, input_file_path: str, output_file_path: str):
+    def run_kmeans_clustering(
+        self, input_file_path: str, output_file_path: str, nodata_val: int = 255
+    ):
         """
         This method reads the input file, runs the K-means clustering on the raster data points and writes the results
         to the output file
@@ -138,10 +145,19 @@ class KMeansClustering(ProcessingBlock):
         # Call clustering operation
         clusters_ar = self.run_kmeans(img_ar)
 
+        if self.propagate_nodata:
+            try:
+                clusters_ar[img_bands[0] == src.meta["nodata"]] = nodata_val
+            except KeyError:
+                logger.warning(
+                    "Propagation of nodata requested, but nodata value in input not set. Ignoring."
+                )
+
         # Copy geo tif metadata to the output image and write it to a file
         dst_meta = src.meta.copy()
         dst_meta["count"] = 1
         dst_meta["dtype"] = "uint8"
+        dst_meta["nodata"] = nodata_val
         logger.info("dst_meta:")
         logger.info(dst_meta)
         with rio.open(output_file_path, "w", **dst_meta) as dst:

--- a/src/kmeans_clustering.py
+++ b/src/kmeans_clustering.py
@@ -70,11 +70,7 @@ class KMeansClustering(ProcessingBlock):
     """
 
     def __init__(
-        self,
-        n_clusters: int = 6,
-        n_iterations: int = 10,
-        n_sieve_pixels: int = 64,
-        propagate_nodata: bool = False,
+        self, n_clusters: int = 6, n_iterations: int = 10, n_sieve_pixels: int = 64,
     ):
         """
         It is possible to set all parameters for testing etc, but in a standard scenario
@@ -88,7 +84,6 @@ class KMeansClustering(ProcessingBlock):
         self.n_clusters = n_clusters
         self.n_iterations = n_iterations
         self.n_sieve_pixels = n_sieve_pixels
-        self.propagate_nodata = propagate_nodata
 
     def run_kmeans(self, img_ar: np.ndarray) -> np.ndarray:
         """
@@ -145,13 +140,12 @@ class KMeansClustering(ProcessingBlock):
         # Call clustering operation
         clusters_ar = self.run_kmeans(img_ar)
 
-        if self.propagate_nodata:
-            try:
-                clusters_ar[img_bands[0] == src.meta["nodata"]] = nodata_val
-            except KeyError:
-                logger.warning(
-                    "Propagation of nodata requested, but nodata value in input not set. Ignoring."
-                )
+        try:
+            clusters_ar[img_bands[0] == src.meta["nodata"]] = nodata_val
+        except KeyError:
+            logger.warning(
+                "Propagation of nodata requested, but nodata value in input not set. Ignoring."
+            )
 
         # Copy geo tif metadata to the output image and write it to a file
         dst_meta = src.meta.copy()

--- a/src/kmeans_clustering.py
+++ b/src/kmeans_clustering.py
@@ -144,7 +144,7 @@ class KMeansClustering(ProcessingBlock):
             clusters_ar[img_bands[0] == src.meta["nodata"]] = nodata_val
         except KeyError:
             logger.warning(
-                "Propagation of nodata requested, but nodata value in input not set. Ignoring."
+                "Propagation of nodata attempted, but nodata value in input not set. Ignoring."
             )
 
         # Copy geo tif metadata to the output image and write it to a file

--- a/tests/test_kmeans_clustering.py
+++ b/tests/test_kmeans_clustering.py
@@ -70,9 +70,7 @@ def test_process():
 
 
 def test_process_float_with_nodata():
-    lcc = KMeansClustering(
-        n_clusters=5, n_iterations=5, n_sieve_pixels=1, propagate_nodata=True
-    )
+    lcc = KMeansClustering(n_clusters=5, n_iterations=5, n_sieve_pixels=1)
     with TestDirectoryContext(Path("/tmp")) as temp:
         image_path, _ = SyntheticImage(
             100, 100, 4, "float", out_dir=temp / "input", nodata=-9999.0, nodata_fill=5

--- a/tests/test_kmeans_clustering.py
+++ b/tests/test_kmeans_clustering.py
@@ -42,7 +42,7 @@ def test_process():
     lcc = KMeansClustering(n_clusters=5, n_iterations=5, n_sieve_pixels=1)
     with TestDirectoryContext(Path("/tmp")) as temp:
         image_path, _ = SyntheticImage(
-            100, 100, 4, "uint16", out_dir=temp / "input"
+            100, 100, 4, "uint16", out_dir=temp / "input", nodata=-1
         ).create(seed=100)
         input_fc = FeatureCollection(
             [
@@ -65,8 +65,6 @@ def test_process():
         )
         output_fc = lcc.process(input_fc)
         assert output_fc.features
-        with pytest.raises(UP42Error, match=r".*[NO_INPUT_ERROR].*"):
-            lcc.process(FeatureCollection([]))
 
 
 def test_process_float_with_nodata():

--- a/tests/test_kmeans_clustering.py
+++ b/tests/test_kmeans_clustering.py
@@ -1,10 +1,12 @@
 import unittest.mock as mock
 from pathlib import Path
+import os
 
 import numpy as np
 import pytest
 
 from geojson import FeatureCollection, Feature
+import rasterio as rio
 
 from blockutils.common import ensure_data_directories_exist, TestDirectoryContext
 from blockutils.syntheticimage import SyntheticImage
@@ -63,9 +65,48 @@ def test_process():
         )
         output_fc = lcc.process(input_fc)
         assert output_fc.features
-
         with pytest.raises(UP42Error, match=r".*[NO_INPUT_ERROR].*"):
             lcc.process(FeatureCollection([]))
+
+
+def test_process_float_with_nodata():
+    lcc = KMeansClustering(
+        n_clusters=5, n_iterations=5, n_sieve_pixels=1, propagate_nodata=True
+    )
+    with TestDirectoryContext(Path("/tmp")) as temp:
+        image_path, _ = SyntheticImage(
+            100, 100, 4, "float", out_dir=temp / "input", nodata=-9999.0, nodata_fill=5
+        ).create(seed=100)
+        input_fc = FeatureCollection(
+            [
+                Feature(
+                    geometry={
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [-8.89411926269531, 38.61687046392973],
+                                [-8.8604736328125, 38.61687046392973],
+                                [-8.8604736328125, 38.63939998171362],
+                                [-8.89411926269531, 38.63939998171362],
+                                [-8.89411926269531, 38.61687046392973],
+                            ]
+                        ],
+                    },
+                    properties={"up42.data_path": str(image_path.name)},
+                )
+            ]
+        )
+        output_fc = lcc.process(input_fc)
+        assert output_fc.features
+
+        with rio.open(
+            os.path.join(
+                "/tmp/output", output_fc.features[0]["properties"]["up42.data_path"]
+            )
+        ) as src:
+            assert src.meta["nodata"] == 255
+            band = src.read(1)
+            assert np.all(band[:5, :5] == 255)
 
 
 def test_raise_if_too_large():


### PR DESCRIPTION
The scikit-learn kmeans algorithm does not understand nodata nor can it be told to ignore specific values in the input array. There are algorithms that can do that, but they would need to be implemented by hand. Not undoable, but also probably not worth it.
Nodata values therefore also influence the results and will be part of the resulting clusters. If the nodata value has a large distance (L2 norm) from the actual values as in the case of our NDVI block, the nodata values will become a separate cluster.
I therefore think it should be the choice of the user if nodata areas from the input image should be propagated or not hence the new option.
In any case, the block will not fail any more if given nodata values out of its data range as it did before.

Will need to be documented.